### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=id">Bahasa Indonesia</a>
+        | <a href="https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=as">অসমীয়া</
+      </div>
+    </div>
+  </details>
+</div>
+
 # 🗺️ Pathfinder
 
 <div align="center">


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search, and it's open source project, we can change web or local file mode.

The updated links can be previewed in my forked repository: https://github.com/openaitx-system/pathfinder/tree/Auto_translate_README_and_Wiki

Demo links : 
- [Español](https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=es)
- [简体中文](https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=ko)
- [Français](https://openaitx.github.io/view.html?user=shadowoff09&project=pathfinder&lang=fr)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962  " />

If this doesn't align with your expectations, feel free to close this PR. Thanks for your time! 🙌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a collapsible language selector at the top of README providing access to content in multiple languages including English, Chinese, Japanese, Korean, and others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->